### PR TITLE
added aspect ratio for containing the image height

### DIFF
--- a/pages/hulp-bieden.vue
+++ b/pages/hulp-bieden.vue
@@ -13,6 +13,7 @@
         <v-img
           :src="require('@/assets/logo-niet-alleen.svg')"
           max-width="200px"
+          aspect-ratio="5"
           position="center center"
           contain
         />

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,6 +14,7 @@
           <v-img
             :src="require('@/assets/logo-niet-alleen.svg')"
             max-width="200px"
+            aspect-ratio="5"
             position="center center"
             contain
           />

--- a/pages/over.vue
+++ b/pages/over.vue
@@ -11,6 +11,7 @@
           <v-img
             :src="require('@/assets/logo-niet-alleen.svg')"
             max-width="200px"
+            aspect-ratio="5"
             class="mx-auto my-8"
             position="center center"
             contain


### PR DESCRIPTION
## Impact ##
Wanneer deze PR wordt gemerged, dan heeft het nietalleen logo een aspect ratio van 5, waardoor deze altijd 5x1 wordt weergeven en altijd een hoogte heeft. Dit lost het probleem op dat firefox de afbeelding geen hoogte geeft.

## Hoe te testen ##
kijk of het logo verschijnt in firefox.

## Te controleren ##
☐  Zijn er voldoende inline comments?

☐  Is de `README.md` bijgewerkt?

☐  Voldoet het aan de criteria van de bijbehorende story?