### PR TITLE
NAL-53 visuele bugfixes

### DIFF
--- a/components/NeedHelpForm.vue
+++ b/components/NeedHelpForm.vue
@@ -38,7 +38,7 @@
           outlined
           required
           suffix="2/6"
-          class="mb-4"
+          class="mb-2"
         />
         <v-text-field
           v-model="postalCode"
@@ -49,7 +49,7 @@
           outlined
           required
           suffix="3/6"
-          class="mb-4"
+          class="mb-2"
         />
         <v-text-field
           v-model="phoneNumber"
@@ -60,7 +60,7 @@
           outlined
           required
           suffix="4/6"
-          class="mb-4"
+          class="mb-2"
         />
         <v-select
           v-model="requestType"
@@ -73,7 +73,7 @@
           required
           multiple
           suffix="5/6"
-          class="mb-4"
+          class="mb-2"
         />
         <v-expand-transition>
           <v-textarea
@@ -86,7 +86,7 @@
             validate-on-blur
             outlined
             required
-            class="mb-4"
+            class="mb-2"
           />
         </v-expand-transition>
         <v-radio-group

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -59,7 +59,6 @@ export default {
   },
   computed: {
     currentPageHasTab () {
-      console.log(this.$nuxt.$route.path === this.activeTab)
       return this.$nuxt.$route.path === this.activeTab
     }
   }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -15,6 +15,7 @@
           color="primary"
           slider-size="4"
           fixed-tabs
+          :class="{'has-no-active': !currentPageHasTab}"
         >
           <v-tab key="1" exact to="/">
             Ik zoek hulp
@@ -37,7 +38,7 @@
     <v-content>
       <nuxt />
     </v-content>
-    <v-footer color="primary">
+    <v-footer color="primary py-5">
       <p class="caption white--text mx-auto">
         <nuxt-link to="/over" class="white--text">
           Over ons
@@ -55,7 +56,13 @@
 export default {
   data () {
     return {
-      activeTab: '/'
+      activeTab: null
+    }
+  },
+  computed: {
+    currentPageHasTab () {
+      console.log(this.$nuxt.$route.path === this.activeTab)
+      return this.$nuxt.$route.path === this.activeTab
     }
   }
 }
@@ -80,5 +87,11 @@ export default {
   }
   .v-slide-group__content {
     width: 100%;
+  }
+
+  .has-no-active {
+    .v-tabs-slider-wrapper {
+      opacity: 0;
+    }
   }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -40,9 +40,7 @@
     </v-content>
     <v-footer color="primary py-5">
       <p class="caption white--text mx-auto">
-        <nuxt-link to="/over" class="white--text">
-          Over ons
-        </nuxt-link>
+        <nuxt-link to="/over" class="white--text wrap-whitespace">Over ons</nuxt-link>
         <span class="mx-2">|</span>
         <a href="https://www.eo.nl/algemene-voorwaarden" class="white--text">Algemene voorwaarden</a>
         <span class="mx-2">|</span>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -44,7 +44,7 @@
           Over ons
         </nuxt-link>
         <span class="mx-2">|</span>
-        <a href="https://www.eo.nl/algemene-voorwaarden" class="white--text">Algemen voorwaarden</a>
+        <a href="https://www.eo.nl/algemene-voorwaarden" class="white--text">Algemene voorwaarden</a>
         <span class="mx-2">|</span>
         <a href="https://www.eo.nl/privacy" class="white--text">Privacyverklaring</a>
       </p>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -74,7 +74,6 @@ export default {
     text-transform: none;
 
     &--active {
-      color: #000000 !important;
       font-weight: bold;
     }
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -46,7 +46,7 @@
             <strong>vrijdag:</strong>
             van 09.00 - 16.00 uur
           </p>
-          <p class="text-left pa-6">
+          <p class="pa-6">
             Een lokale organisatie of kerk zal je zo snel mogelijk benaderen om je te helpen.
           </p>
         </v-flex>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,7 +6,7 @@
         align-center
         class="pa-8 text-center"
       >
-        <v-flex xs12 sm8 md5>
+        <v-flex xs12 sm8 md5 lg4>
           <hero-image
             :src="require('@/assets/hond-uitlaten.jpg')"
             size="400px"

--- a/pages/over.vue
+++ b/pages/over.vue
@@ -38,23 +38,25 @@
             doorgestuurd naar een organisatie bij jou in de buurt. Zo helpen we elkaar in deze bijzondere
             tijd, want je bent #Nietalleen.
           </p>
-          <v-btn
-            href="/"
-            color="primary"
-            class="mt-10"
-            nuxt
-            x-large
-          >
-            Help je hulp nodig?
-          </v-btn>
-          <v-btn
-            href="hulp-bieden"
-            class="mt-4"
-            nuxt
-            x-large
-          >
-            Wil je hulp bieden?
-          </v-btn>
+          <div class="mt-12">
+            <v-btn
+              href="/"
+              color="primary"
+              class="ma-2"
+              nuxt
+              x-large
+            >
+              Help je hulp nodig?
+            </v-btn>
+            <v-btn
+              href="hulp-bieden"
+              class="ma-2"
+              nuxt
+              x-large
+            >
+              Wil je hulp bieden?
+            </v-btn>
+          </div>
         </v-flex>
       </v-layout>
     </section>


### PR DESCRIPTION
## Impact ##
Wanneer deze PR wordt gemerged, zijn de visuele puntjes van Jonathan doorgevoerd:

1. footer meer padding
2. tabbar: active heeft nu paarse tekst
3. tabbar: geen active state meer op de /over pagina
3. Footer **algemen voorwaarden (daar miste nog een e)**
4. footer **over ons** was de underline te lang
5. Het tekstje "Een lokale organisatie of k.... ) gecentreerd
6. De inputfiels wat dichter op elkaar
7. Op desktop de buttons op de "Over ons"-pagina mooier naast elkaar

## Hoe te testen ##
Zie netlify linkje zodadelijk

## Te controleren ##
☐  Zijn er voldoende inline comments?

☐  Is de `README.md` bijgewerkt?

☐  Voldoet het aan de criteria van de bijbehorende story?