### PR TITLE
added cookielink to footer

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -44,7 +44,7 @@
         <span class="mx-2">|</span>
         <a href="https://www.eo.nl/algemene-voorwaarden" class="white--text">Algemene voorwaarden</a>
         <span class="mx-2 d-none d-sm-inline">|</span>
-        <span class="mx-2 d-block d-sm-none">&nbsp;</span>
+        <br class="mx-2 d-sm-none">
         <a href="https://www.eo.nl/privacy" class="white--text">Privacyverklaring</a>
         <span class="mx-2">|</span>
         <a href="https://cookies.nietalleen.nl/sites/EO/eo.nl/settings.html" class="white--text npo_cc_settings_link" rel="noreferrer">Cookie instellingen</a>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -47,7 +47,7 @@
         <br class="mx-2 d-sm-none">
         <a href="https://www.eo.nl/privacy" class="white--text">Privacyverklaring</a>
         <span class="mx-2">|</span>
-        <a href="https://cookies.nietalleen.nl/sites/EO/eo.nl/settings.html" class="white--text npo_cc_settings_link" rel="noreferrer">Cookie instellingen</a>
+        <a href="https://cookies.nietalleen.nl/sites/EO/nietalleen.nl/settings.html" class="white--text npo_cc_settings_link" rel="noreferrer">Cookie instellingen</a>
       </p>
     </v-footer>
   </v-app>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -39,12 +39,15 @@
       <nuxt />
     </v-content>
     <v-footer color="primary py-5">
-      <p class="caption white--text mx-auto">
+      <p class="caption white--text mx-auto text-center">
         <nuxt-link to="/over" class="white--text wrap-whitespace">Over ons</nuxt-link>
         <span class="mx-2">|</span>
         <a href="https://www.eo.nl/algemene-voorwaarden" class="white--text">Algemene voorwaarden</a>
-        <span class="mx-2">|</span>
+        <span class="mx-2 d-none d-sm-inline">|</span>
+        <span class="mx-2 d-block d-sm-none">&nbsp;</span>
         <a href="https://www.eo.nl/privacy" class="white--text">Privacyverklaring</a>
+        <span class="mx-2">|</span>
+        <a href="https://cookies.nietalleen.nl/sites/EO/eo.nl/settings.html" class="white--text npo_cc_settings_link" rel="noreferrer">Cookie instellingen</a>
       </p>
     </v-footer>
   </v-app>


### PR DESCRIPTION
## Impact ##
Wanneer deze PR wordt gemerged, dan kan de gebruiker zijn cookie instellingen beheren. Deze link heeft een href als default en wordt door de CCM module overscheven wanneer nodig door de npo_cc_settings_link class.

## Hoe te testen ##
Op het linkje klikken in de footer en je cookie instellingen aanpassen. Check ook ff verschillende schermformaten.

## Te controleren ##
☐  Zijn er voldoende inline comments?

☐  Is de `README.md` bijgewerkt?

☐  Voldoet het aan de criteria van de bijbehorende story?