### PR TITLE
[Changed] Name of datalayer should be the default name.

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -116,7 +116,6 @@ export default {
   },
   gtm: {
     id: 'GTM-PNF2PX4',
-    layer: 'datalayer',
     variables: { potag1: 'eoportal', potag2: 'nietalleen', potag3: 'eo', potag4: 'eo', potag5: 'omroepportal', potag6: '', potag7: '', potag8: 'site', potag9: 'site', http_status: '200', classification: '', pubdate: 0, pubweek: '01', atinternet_siteid: '59' }
   },
   /*

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -52,7 +52,11 @@ export default {
       { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
       { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@400;700&display=swap' },
       { rel: 'stylesheet', href: 'https://fonts.googleapis.com/css2?family=Bellota&display=swap' }
-    ]
+    ],
+    script: [
+      { innerHTML: 'dataLayer = [{"potag1":"eoportal","potag2":"nietalleen","potag3":"eo","potag4":"eo","potag5":"omroepportal","potag6":"","potag7":"","potag8":"site","potag9":"site","http_status":"200","classification":"","pubdate":0,"pubweek":"01","atinternet_siteid":"59"}]' }
+    ],
+    __dangerouslyDisableSanitizers: ['script']
   },
   /*
   ** Customize the progress-bar color
@@ -115,8 +119,7 @@ export default {
     }
   },
   gtm: {
-    id: 'GTM-PNF2PX4',
-    variables: { potag1: 'eoportal', potag2: 'nietalleen', potag3: 'eo', potag4: 'eo', potag5: 'omroepportal', potag6: '', potag7: '', potag8: 'site', potag9: 'site', http_status: '200', classification: '', pubdate: 0, pubweek: '01', atinternet_siteid: '59' }
+    id: 'GTM-PNF2PX4'
   },
   /*
   ** Build configuration


### PR DESCRIPTION
## Impact ##
Wanneer deze PR wordt gemerged, zal de naam van de variabele datalayer worden veranderd in de default: dataLayer

De dataLayer hoort overigens  niet in de "variables"-attribuut, maar dat is knap slecht gedocumenteerd. DataLayer verhuisd naar het head->scripts deel.

## Hoe te testen ##
https://develop.nietalleen.nl

Zoek in de netwerktab van je console naar "atconnect.npo.nl" 

En controleer NIET de x6 parameter, maar de p-parameter ;-) vergelijk met productie :-) nu staat er netjes nietalleen::/ in plaats van home::/

## Te controleren ##
☐  Zijn er voldoende inline comments?

☐  Is de `README.md` bijgewerkt?

☐  Voldoet het aan de criteria van de bijbehorende story?