### PR TITLE
overwrite api host in netlify config for develop branch app

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,8 @@
     URL = "https://nietalleen.nl"
 
 [context."develop".environment]
+#   Overwrite API host for develop branch/app
+    NIETALLEEN_API_HOST = "https://test-api-nietalleen.eo.nl"
     URL = "https://develop.nietalleen.nl"
 
 [context.deploy-preview.environment]


### PR DESCRIPTION
## Impact ##
Wanneer deze PR wordt gemerged, dan zal de develop-app variant van nietalleen kijken naar de test-app van nietalleen

## Hoe te testen ##
check of de develop website verbind met de test api, ipv de productie api van niet alleen. (deze branch is al gemerged in develop)

## Te controleren ##
☐  Zijn er voldoende inline comments?

☐  Is de `README.md` bijgewerkt?

☐  Voldoet het aan de criteria van de bijbehorende story?