### PR TITLE
Add redirects to the new PIP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,9 @@
 [context.deploy-preview.environment]
 #    NODE_ENV = "development"
     URL = "https://develop.nietalleen.nl"
+
+[[redirects]]
+  from = "/*"
+  to = "https://www.eo.nl/programmas/niet-alleen-nl"
+  status = 200
+  force = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -17,5 +17,5 @@
 [[redirects]]
   from = "/*"
   to = "https://www.eo.nl/programmas/niet-alleen-nl"
-  status = 200
+  status = 301 
   force = true

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,8 @@
+/                      https://www.eo.nl/programmas/niet-alleen-nl
+/hulp-bieden           https://www.eo.nl/programmas/niet-alleen-nl
+/verhalen              https://www.eo.nl/programmas/niet-alleen-nl
+/tv-programma          https://www.eo.nl/programmas/niet-alleen-nl
+/veelgestelde-vragen   https://www.eo.nl/programmas/niet-alleen-nl 
+/doneren               https://www.eo.nl/programmas/niet-alleen-nl
+/over                  https://www.eo.nl/programmas/niet-alleen-nl
+/training-npv          https://www.eo.nl/programmas/niet-alleen-nl

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,8 +1,0 @@
-/                      https://www.eo.nl/programmas/niet-alleen-nl
-/hulp-bieden           https://www.eo.nl/programmas/niet-alleen-nl
-/verhalen              https://www.eo.nl/programmas/niet-alleen-nl
-/tv-programma          https://www.eo.nl/programmas/niet-alleen-nl
-/veelgestelde-vragen   https://www.eo.nl/programmas/niet-alleen-nl 
-/doneren               https://www.eo.nl/programmas/niet-alleen-nl
-/over                  https://www.eo.nl/programmas/niet-alleen-nl
-/training-npv          https://www.eo.nl/programmas/niet-alleen-nl


### PR DESCRIPTION
## Impact ##
Wanneer deze PR wordt gemerged, dan worden alle requests op nietalleen.nl doorgestuurd naar de nieuwe PIP op https://www.eo.nl/programmas/niet-alleen-nl

## Hoe te testen ##
Alle nietalleen url (in google even zoeken) moeten een status 301 geven naar de nieuwe PIP.

Bijvoobeeld: https://deploy-preview-94--nietalleen.netlify.app/verhalen

## Te controleren ##
☐  Zijn er voldoende inline comments?

☐  Is de `README.md` bijgewerkt?

☐  Voldoet het aan de criteria van de bijbehorende story?